### PR TITLE
[docker] : use `--no-cache-dir` flag to `pip` in dockerfiles to save space

### DIFF
--- a/es-curator/Dockerfile
+++ b/es-curator/Dockerfile
@@ -1,10 +1,10 @@
 FROM alpine:3.8.5
 
 RUN apk --no-cache add python py-setuptools py-pip gcc libffi py-cffi python-dev libffi-dev py-openssl musl-dev linux-headers openssl-dev libssl1.0 && \
-    pip install elasticsearch-curator==5.6.0 && \
-    pip install boto3==1.9.59 && \
-    pip install requests-aws4auth==0.9 && \
-    pip install cryptography==2.1.3 && \
+    pip install --no-cache-dir elasticsearch-curator==5.6.0 && \
+    pip install --no-cache-dir boto3==1.9.59 && \
+    pip install --no-cache-dir requests-aws4auth==0.9 && \
+    pip install --no-cache-dir cryptography==2.1.3 && \
     apk del py-pip gcc python-dev libffi-dev musl-dev linux-headers openssl-dev && \
     sed -i '/import sys/a urllib3.contrib.pyopenssl.inject_into_urllib3()' /usr/bin/curator && \
     sed -i '/import sys/a import urllib3.contrib.pyopenssl' /usr/bin/curator && \


### PR DESCRIPTION
using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>